### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The basic steps for usage are:
    environment variables w/propagated meta-data.
 
 Example:
-```
+```yml
 steps:
   # collect the TARGET_ENVIRONMENT, LAMBDA_NAME and DEPLOY_VERSION
   # meta-data with a block step
@@ -48,13 +48,13 @@ steps:
   - command: source .meta-env && deploy $TARGET_ENVIRONMENT $LAMBDA_NAME $DEPLOY_VERSION
     label: ":rocket: do deployment"
     plugins:
-      shippingeasy/meta-env#v0.1.2:
-        meta-data:
-          - TARGET_ENVIRONMENT
-          - LAMBDA_NAME
-          - DEPLOY_VERSION
-      docker-compose#v2.5.1:
-        run: deploy-env
+      - shippingeasy/meta-env#v0.1.2:
+          meta-data:
+            - TARGET_ENVIRONMENT
+            - LAMBDA_NAME
+            - DEPLOY_VERSION
+      - docker-compose#v2.5.1:
+          run: deploy-env
 ```
 
 The following happens with the above pipeline:


### PR DESCRIPTION
Hi @lwoodson! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.